### PR TITLE
FEAT: issue#87: allow user to add custom styles for the icon

### DIFF
--- a/src/defaultConfig/components/notificationBase.tsx
+++ b/src/defaultConfig/components/notificationBase.tsx
@@ -23,7 +23,9 @@ export const NotificationBase = (props: NotificationOwnProps & MergedNotificatio
       : require('../../assets/images/close-darkMode.png')
   const { remove } = useNotificationController()
 
-  const renderLeftIcon = () => <Image source={props.leftIconSource!} style={{...styles.icon, ...props?.imageStyle}} />
+  const renderLeftIcon = () => (
+    <Image source={props.leftIconSource!} style={{ ...styles.icon, ...props?.imageStyle }} />
+  )
 
   const renderRightIcon = () => (
     <TouchableOpacity

--- a/src/defaultConfig/components/notificationBase.tsx
+++ b/src/defaultConfig/components/notificationBase.tsx
@@ -23,7 +23,7 @@ export const NotificationBase = (props: NotificationOwnProps & MergedNotificatio
       : require('../../assets/images/close-darkMode.png')
   const { remove } = useNotificationController()
 
-  const renderLeftIcon = () => <Image source={props.leftIconSource!} style={styles.icon} />
+  const renderLeftIcon = () => <Image source={props.leftIconSource!} style={{...styles.icon, ...props?.imageStyle}} />
 
   const renderRightIcon = () => (
     <TouchableOpacity

--- a/src/defaultConfig/mergeProps.ts
+++ b/src/defaultConfig/mergeProps.ts
@@ -63,6 +63,6 @@ export const mergeProps = (
           defaultGlobalConfig?.defaultIconType
       ),
     onPress: props.onPress ?? undefined,
-    imageStyle: chooseProps('imageStyle')
+    imageStyle: chooseProps('imageStyle'),
   }
 }

--- a/src/defaultConfig/mergeProps.ts
+++ b/src/defaultConfig/mergeProps.ts
@@ -63,5 +63,6 @@ export const mergeProps = (
           defaultGlobalConfig?.defaultIconType
       ),
     onPress: props.onPress ?? undefined,
+    imageStyle: chooseProps('imageStyle')
   }
 }

--- a/src/defaultConfig/types.ts
+++ b/src/defaultConfig/types.ts
@@ -1,6 +1,6 @@
 import type { NotificationPosition } from '../types/config'
 import type { DefaultKeys, defaultVariants } from './defaultConfig'
-import type { ImageSourcePropType } from 'react-native'
+import type { ImageSourcePropType, ImageStyle } from 'react-native'
 
 export type DefaultVariants = typeof defaultVariants
 export type NotificationVariants = keyof DefaultVariants
@@ -37,6 +37,7 @@ export type NotificationStyleConfig = Partial<{
   defaultIconType: IconVisualStyle
   leftIconSource: ImageSourcePropType
   borderType: BorderType
+  imageStyle: ImageStyle
 }>
 
 export type StyleProps = { style?: Partial<NotificationStyleConfig> }


### PR DESCRIPTION
Add proper types for 'imageStyle' property.
Add new key in a returned object in mergeProps.ts
Update notificationBase.tsx - method renderLeftIcon in style prop spreads hardcoded styles and the one passed as imageStyle

Closes #87 