### PR TITLE
FIX: Animated wrapper which is handling gestures has height set to 30 when notification is dismissed/turned off

### DIFF
--- a/src/core/utils/styles.ts
+++ b/src/core/utils/styles.ts
@@ -5,7 +5,7 @@ export const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     width: Constants.notificationWidth,
-    minHeight: 30,
+    minHeight: 0,
     left: 0,
     backgroundColor: 'transparent',
     top: 0,


### PR DESCRIPTION
Why: 

Before/after displaying the notification, the animated wrapper was blocking part of the screen. The user was unable to touch any pressable/touchable element covered by the wrapper. 

Expected behavior:

When notification is dismissed/hidden, the user can press elements on the top of the screen. 

Solution: 

Set minHeight for Animated wrapper to 0. 

