### PR TITLE
feat:  out of the box handling of isNotch

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-native-builder-bob": "^0.18.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^2.2.4",
+    "react-native-device-info": "^8.4.8",
     "release-it": "^14.2.2",
     "typescript": "^4.1.3"
   },
@@ -76,7 +77,8 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.4"
+    "react-native-reanimated": "^2.2.4",
+    "react-native-device-info": "^8.4.8"
   },
   "jest": {
     "preset": "react-native",

--- a/src/core/utils/pickers.ts
+++ b/src/core/utils/pickers.ts
@@ -4,12 +4,13 @@ import type { EmitParam } from '../services/types'
 import type { DefaultKeys } from '../../defaultConfig/defaultConfig'
 import type { DefaultStylesConfigs } from '../../defaultConfig/types'
 import type { KeyType } from '../../types/misc'
+import { hasNotch } from 'react-native-device-info'
 
 export const getTopOffset = (
   globalConfig: NotificationsConfig<VariantsMap>,
   notificationHeight: number
 ) => {
-  const isNotch = globalConfig.isNotch
+  const isNotch = (typeof globalConfig.isNotch === "undefined")  ? hasNotch() : globalConfig.isNotch;
   const extraSpace = 50
   const topPosition = isNotch ? extraSpace : 10
   const notificationPosition = globalConfig.notificationPosition

--- a/src/core/utils/pickers.ts
+++ b/src/core/utils/pickers.ts
@@ -10,7 +10,7 @@ export const getTopOffset = (
   globalConfig: NotificationsConfig<VariantsMap>,
   notificationHeight: number
 ) => {
-  const isNotch = (typeof globalConfig.isNotch === "undefined")  ? hasNotch() : globalConfig.isNotch;
+  const isNotch = typeof globalConfig.isNotch === 'undefined' ? hasNotch() : globalConfig.isNotch
   const extraSpace = 50
   const topPosition = isNotch ? extraSpace : 10
   const notificationPosition = globalConfig.notificationPosition


### PR DESCRIPTION
Add peer and dev Dependencies: react-native-device-info

Add 'typeof' check for globalConfig.isNotch:
    - if developer set global isNotch, then library is using this setup
    - otherwise (undefined), library is checking the notch parameter  using react-native-device-info

Closes #97 