### PR TITLE
fix: hook useNotificationController is not providing method 'modify'

### DIFF
--- a/src/hooks/useNotificationController.ts
+++ b/src/hooks/useNotificationController.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import NotificationEmitterApi from '../core/services/NotificationEmitterApi'
 import { useVariantsRendererContext } from '../core/renderers/VariantsRenderer'
+import type { ModifiedEmitParam } from 'src/core/services/types'
 
 export const useNotificationController = () => {
   const context = useVariantsRendererContext()
@@ -12,5 +13,12 @@ export const useNotificationController = () => {
     [context?.id]
   )
 
-  return { remove }
+  const modify = useCallback(
+    (id?: string, params: Partial<ModifiedEmitParam> = {}) => {
+      NotificationEmitterApi.modify(id ?? context?.id ?? '', params)
+    },
+    [context?.id]
+  )
+
+  return { remove, modify }
 }


### PR DESCRIPTION
Add 'modify' method to hook useNotificationController
Add export in useNotificationController
Import type for required arguments in 'modify' method

Closes #105 