### PR TITLE
chore: update type import for generateAnimationConfig declaration

### DIFF
--- a/src/core/utils/generateAnimationConfig.ts
+++ b/src/core/utils/generateAnimationConfig.ts
@@ -1,4 +1,4 @@
-import type { CustomAnimationConfig } from 'src/types/animations'
+import type { CustomAnimationConfig } from '../../types/animations'
 
 export const generateAnimationConfig = (config: CustomAnimationConfig): CustomAnimationConfig => {
   return config


### PR DESCRIPTION
Because of the wrong type import, the `generateAnimationConfig` was not being properly typed when using in context of other application (installed via npm). Updating the import path should fix that issue