### PR TITLE
feat: add feature to simplify initial configuration

### DIFF
--- a/src/core/gestures/shouldTriggerGesture.ts
+++ b/src/core/gestures/shouldTriggerGesture.ts
@@ -13,13 +13,15 @@ export const shouldTriggerGesture = (config: GestureConfig, gesture: GestureProp
     }
     case 'x':
       return (
-        !isValueInRange(gesture.distance[0], config.activationDistances) ||
-        !isValueInRange(gesture.velocity[0], config.activationVelocities)
+        // fallback value if config gets only 'direction' param; values reflect FullGestureConfig.x in defualtGestureConfig
+        !isValueInRange(gesture.distance[0], config.activationDistances ?? 100) ||
+        !isValueInRange(gesture.velocity[0], config.activationVelocities ?? 2000)
       )
     case 'y':
       return (
-        !isValueInRange(gesture.distance[1], config.activationDistances) ||
-        !isValueInRange(gesture.velocity[1], config.activationVelocities)
+        // fallback value if config gets only 'direction' param; values reflect FullGestureConfig.y in defualtGestureConfig
+        !isValueInRange(gesture.distance[1], config.activationDistances ?? 100) ||
+        !isValueInRange(gesture.velocity[1], config.activationVelocities ?? 1000)
       )
     case 'none':
     default:

--- a/src/types/gestures.ts
+++ b/src/types/gestures.ts
@@ -8,8 +8,8 @@ export interface GestureProps {
 }
 
 export interface GestureConfigProps {
-  activationDistances: Range | number
-  activationVelocities: Range | number
+  activationDistances?: Range | number
+  activationVelocities?: Range | number
 }
 
 export interface NoneGestureConfig {


### PR DESCRIPTION
1. Update types: GestureConfigProps are optional in gestures.ts
2. activationVelicities and activationDistantes get default values (the same
as in defaultGestureConfig for FullGestureConfig), when the gestureConfig has
set direction for 'y' or 'x' axis. Developers can override defaults.

Closes: #119 