### PR TITLE
docs: update imports in code snippets - old library name

### DIFF
--- a/docs/docs/api/apiReference.md
+++ b/docs/docs/api/apiReference.md
@@ -15,7 +15,7 @@ Parameter used to configure animation. Can be set up for the entire app or selec
 Below is the global configuration:
 
 ```tsx
-import { createNotifications, RotateInRotateOut } from 'react-native-notification'
+import { createNotifications, RotateInRotateOut } from 'react-native-notificated'
 
 const { NotificationsProvider } = createNotifications({
     animationConfig: RotateInRotateOut
@@ -25,7 +25,7 @@ const { NotificationsProvider } = createNotifications({
 And it can be overwritten in local scope, when calling notification:
 
 ```tsx
-import { SlideInLeftSlideOutRight } from 'react-native-notification'
+import { SlideInLeftSlideOutRight } from 'react-native-notificated'
 
 [...]
 
@@ -53,7 +53,7 @@ We've prepared for you a couple of ready-to-use animations (just import them fro
 API used to initialize the library in the project.
 
 ```tsx
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 
 const { NotificationsProvider } = createNotifications()
 ```

--- a/docs/docs/intro/animations/changing-transitions.md
+++ b/docs/docs/intro/animations/changing-transitions.md
@@ -13,7 +13,7 @@ Depending on whether you want to change the default transitions for the whole ap
 1. Change the animation **type** in the config object of `createNotification`:
 
 ```typescript
-import { createNotifications, RotateInRotateOut } from 'react-native-notification'
+import { createNotifications, RotateInRotateOut } from 'react-native-notificated'
 
 const { useNotifications } = createNotifications({
   animationConfig: RotateInRotateOut,
@@ -23,7 +23,7 @@ const { useNotifications } = createNotifications({
 2. Use the `config.animationConfig` property in the **payload** of a `notify` function:
 
 ```typescript
-import { createNotifications, SlideInLeftSlideOutRight } from 'react-native-notification'
+import { createNotifications, SlideInLeftSlideOutRight } from 'react-native-notificated'
 
 const { useNotifications } = createNotifications()
 

--- a/docs/docs/intro/basics/basic-configuration.md
+++ b/docs/docs/intro/basics/basic-configuration.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 ### Create Notifications
 
 ```tsx
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 
 const { NotificationsProvider } = createNotifications()
 ```

--- a/docs/docs/intro/basics/basic-usage.md
+++ b/docs/docs/intro/basics/basic-usage.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ### Create Notifications
 
 ```tsx
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 
 const { NotificationsProvider, useNotifications, ...events } = createNotifications()
 ```

--- a/docs/docs/intro/comprehensive-configuration/order-of-settings-overwriting.md
+++ b/docs/docs/intro/comprehensive-configuration/order-of-settings-overwriting.md
@@ -21,7 +21,7 @@ Let's consider the case where we set all possible options for single `success` n
 ```jsx
 import React from 'react'
 import { SafeAreaView } from 'react-native'
-import { createNotifications, SlideInLeftSlideOutRight } from 'react-native-notification'
+import { createNotifications, SlideInLeftSlideOutRight } from 'react-native-notificated'
 import { styles } from './styles'
 import { SuccessButton } from '../components/basicExamples/SuccessButton'
 

--- a/docs/docs/intro/default-variants-config/default-variants.md
+++ b/docs/docs/intro/default-variants-config/default-variants.md
@@ -11,7 +11,7 @@ If you just trigger the notification, like in the example below (we trigger the 
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { useNotifications, NotificationsProvider } = createNotifications()

--- a/docs/docs/intro/default-variants-config/global-config.md
+++ b/docs/docs/intro/default-variants-config/global-config.md
@@ -118,7 +118,7 @@ Let's start with the basic notification settings with some global style.
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { useNotifications, NotificationsProvider } = createNotifications({
@@ -177,7 +177,7 @@ If we set there only `borderRadius` property for some value, then only `borderRa
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { useNotifications, NotificationsProvider } = createNotifications({
@@ -241,7 +241,7 @@ So if we set `borderRadius` in `globalConfig` for `50` as we did in the example 
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { useNotifications, NotificationsProvider } = createNotifications({

--- a/docs/docs/intro/default-variants-config/position.md
+++ b/docs/docs/intro/default-variants-config/position.md
@@ -25,7 +25,7 @@ Depending on whether you want to change the notification position for the whole 
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { NotificationsProvider, useNotifications } = createNotifications({
@@ -66,7 +66,7 @@ Now all the notifications in the app will be displayed in the middle of the scre
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { NotificationsProvider, useNotifications } = createNotifications({

--- a/docs/docs/intro/default-variants-config/props-config.md
+++ b/docs/docs/intro/default-variants-config/props-config.md
@@ -110,7 +110,7 @@ To understand it perfectly, let's take a look at the few examples below.
 ```jsx
 import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 
 const { useNotifications, NotificationsProvider } = createNotifications({

--- a/docs/docs/intro/examples/custom-components-examples.md
+++ b/docs/docs/intro/examples/custom-components-examples.md
@@ -123,7 +123,7 @@ Please notice, that we pass props to those components. I will explain how to do 
 ```tsx
 import React from 'react'
 import { SafeAreaView } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { styles } from './styles'
 import { Advertisement } from '../components/customVariants/Advertisement'
 import { CustomInfo } from '../components/customVariants/CustomInfo'

--- a/docs/docs/intro/examples/custom-examples.md
+++ b/docs/docs/intro/examples/custom-examples.md
@@ -23,7 +23,7 @@ Let's take a look at the code and the visualisations then:
 import React from 'react'
 import { SafeAreaView } from 'react-native'
 import { styles } from './styles'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { SuccessButton } from '../components/basicExamples/SuccessButton'
 import { ErrorButton } from '../components/basicExamples/ErrorButton'
 import { WarningButton } from '../components/basicExamples/WarningButton'

--- a/docs/docs/intro/examples/dark-mode-examples.md
+++ b/docs/docs/intro/examples/dark-mode-examples.md
@@ -22,7 +22,7 @@ Let's take a look at the code and the visualizations then:
 ```jsx
 import React from 'react'
 import { SafeAreaView } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { SuccessButton } from '../components/basicExamples/SuccessButton'
 import { ErrorButton } from '../components/basicExamples/ErrorButton'
 import { WarningButton } from '../components/basicExamples/WarningButton'

--- a/docs/docs/intro/examples/default-examples.md
+++ b/docs/docs/intro/examples/default-examples.md
@@ -15,7 +15,7 @@ Let's go then!
 ```jsx
 import React, { useState } from 'react'
 import { SafeAreaView } from 'react-native'
-import { createNotifications, useNotificationController } from 'react-native-notification'
+import { createNotifications, useNotificationController } from 'react-native-notificated'
 import { SuccessButton } from '../components/basicExamples/SuccessButton'
 import { ErrorButton } from '../components/basicExamples/ErrorButton'
 import { WarningButton } from '../components/basicExamples/WarningButton'

--- a/docs/docs/intro/examples/global-config-examples.md
+++ b/docs/docs/intro/examples/global-config-examples.md
@@ -23,7 +23,7 @@ Let's take a look at the code and the visualizations then:
 ```jsx
 import React from 'react'
 import { SafeAreaView } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { SuccessButton } from '../components/basicExamples/SuccessButton'
 import { ErrorButton } from '../components/basicExamples/ErrorButton'
 import { WarningButton } from '../components/basicExamples/WarningButton'

--- a/docs/docs/intro/examples/global-types-config-examples.md
+++ b/docs/docs/intro/examples/global-types-config-examples.md
@@ -21,7 +21,7 @@ Let's take a look at the code and the visualizations then:
 ```jsx
 import React from 'react'
 import { SafeAreaView } from 'react-native'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 import { SuccessButton } from '../components/basicExamples/SuccessButton'
 import { ErrorButton } from '../components/basicExamples/ErrorButton'
 import { WarningButton } from '../components/basicExamples/WarningButton'

--- a/docs/docs/intro/examples/redux-example.md
+++ b/docs/docs/intro/examples/redux-example.md
@@ -20,7 +20,7 @@ import React from 'react'
 import { store } from '../redux/store'
 import { Provider } from 'react-redux'
 import { LoginForm } from '../components/loginForm/LoginForm'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 
 const { NotificationsProvider } = createNotifications({
   isNotch: true,
@@ -201,7 +201,7 @@ import {
 import { fetchUsers, updateLogin, updatePassword } from '../../redux/reducers'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { styles } from './styles'
-import { createNotifications } from 'react-native-notification'
+import { createNotifications } from 'react-native-notificated'
 
 export const { notify } = createNotifications()
 


### PR DESCRIPTION
Changed the imports in the code snippets in the documentation as they 
were addressing the old library name
