### PR TITLE
fix: add missing firebase modulars to podfile

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,8 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+pod 'Firebase', :modular_headers => true
+pod 'FirebaseCore', :modular_headers => true
+pod 'GoogleUtilities', :modular_headers => true
 
 platform :ios, '11.0'
 


### PR DESCRIPTION
It was missing in the pr with foreground notifications example