### PR TITLE
fix: notification's shadow artifacts on Android (use needsOffscreenAlphaCompositing={true})

### DIFF
--- a/src/core/renderers/AnimationRenderer.tsx
+++ b/src/core/renderers/AnimationRenderer.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react'
 import Animated from 'react-native-reanimated'
 import { LongPressGestureHandler } from 'react-native-gesture-handler'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import type { NotificationState } from '../hooks/useNotificationsStates'
 import type { AnimationAPI } from '../hooks/useAnimationAPI'
 import { styles } from '../utils/styles'
@@ -18,7 +18,9 @@ type Props = {
 
 export const AnimationRenderer = ({ children, animationAPI, state }: Props) => {
   return (
-    <Animated.View style={[animationAPI.animatedStyles]} needsOffscreenAlphaCompositing>
+    <Animated.View
+      style={[animationAPI.animatedStyles]}
+      needsOffscreenAlphaCompositing={Platform.OS === 'android'}>
       {state.notificationEvent && (
         <LongPressGestureHandler
           minDurationMs={800}

--- a/src/core/renderers/AnimationRenderer.tsx
+++ b/src/core/renderers/AnimationRenderer.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 export const AnimationRenderer = ({ children, animationAPI, state }: Props) => {
   return (
-    <Animated.View style={[animationAPI.animatedStyles]}>
+    <Animated.View style={[animationAPI.animatedStyles]} needsOffscreenAlphaCompositing>
       {state.notificationEvent && (
         <LongPressGestureHandler
           minDurationMs={800}


### PR DESCRIPTION
* fix shadow artifacts on Android (use needsOffscreenAlphaCompositing={true})
* ref: https://github.com/facebook/react-native/issues/23090#issuecomment-710803743

ANDROID OS - before:


https://github.com/TheWidlarzGroup/react-native-notificated/assets/55193208/470fe03b-40df-4f9a-9c09-ba885e44f9e0


ANDROID OS - after:

https://github.com/TheWidlarzGroup/react-native-notificated/assets/55193208/0247afcf-4dae-4532-80c4-894bc09678f1



Closes #224 