### PR TITLE
fixed: no children prop (types)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -57,8 +57,8 @@ export type UseNotification<V extends VariantsMap = Variants> = () => Emmiter<V>
 
 export type CreateNotificationsReturnType<V extends VariantsMap = Variants> = {
   useNotifications: UseNotification<V>
-  NotificationsProvider: React.FC
-  ModalNotificationsProvider: React.FC<{ notificationTopPosition?: number }>
+  NotificationsProvider: React.FC<React.PropsWithChildren>
+  ModalNotificationsProvider: React.FC<React.PropsWithChildren<{ notificationTopPosition?: number }>>
   CustomVariantsTypeHelper: V
 } & ReturnType<UseNotification<V>>
 


### PR DESCRIPTION
With React 18 the implicit children prop was removed.  You can read why here: https://solverfox.dev/writing/no-implicit-children/