### PR TITLE
fix: no children prop (types) - followup

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -57,8 +57,10 @@ export type UseNotification<V extends VariantsMap = Variants> = () => Emmiter<V>
 
 export type CreateNotificationsReturnType<V extends VariantsMap = Variants> = {
   useNotifications: UseNotification<V>
-  NotificationsProvider: React.FC<React.PropsWithChildren>
-  ModalNotificationsProvider: React.FC<React.PropsWithChildren<{ notificationTopPosition?: number }>>
+  NotificationsProvider: React.FC<React.PropsWithChildren<Record<never, any>>>
+  ModalNotificationsProvider: React.FC<
+    React.PropsWithChildren<{ notificationTopPosition?: number }>
+  >
   CustomVariantsTypeHelper: V
 } & ReturnType<UseNotification<V>>
 


### PR DESCRIPTION
* improve types for NotificationsProvider to add backward compatibility for react 17 and @types/react 17