### PR TITLE
fix: split `useStatusBarHeightDetector` hook into web and native flavors

### DIFF
--- a/src/core/hooks/useStatusBarHeightDetector.native.ts
+++ b/src/core/hooks/useStatusBarHeightDetector.native.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import { NativeModules, Platform, StatusBar } from 'react-native'
+
+type Props = {
+  isPortraitMode: boolean
+}
+
+const NativeStatusBarManager = require('react-native/Libraries/Components/StatusBar/NativeStatusBarManagerIOS')
+
+export const useStatusBarHeightDetector = ({ isPortraitMode }: Props) => {
+  const { StatusBarManager } = NativeModules
+  const [barHeight, setBarHeight] = useState(0)
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return setBarHeight(StatusBar.currentHeight ?? 0)
+    // handling edge case when app is opened in landscape mode and barHeight = 0
+    const StatusBarManagerModule = NativeStatusBarManager?.default || StatusBarManager
+
+    StatusBarManagerModule?.getHeight(({ height }: { height: number }) =>
+      setBarHeight(isPortraitMode && height !== 0 ? height : 50)
+    )
+  }, [StatusBarManager, isPortraitMode])
+
+  return {
+    statusBarHeight: barHeight,
+  }
+}

--- a/src/core/hooks/useStatusBarHeightDetector.ts
+++ b/src/core/hooks/useStatusBarHeightDetector.ts
@@ -1,27 +1,9 @@
-import { useEffect, useState } from 'react'
-import { NativeModules, Platform, StatusBar } from 'react-native'
-
 type Props = {
   isPortraitMode: boolean
 }
 
-const NativeStatusBarManager = require('react-native/Libraries/Components/StatusBar/NativeStatusBarManagerIOS')
-
-export const useStatusBarHeightDetector = ({ isPortraitMode }: Props) => {
-  const { StatusBarManager } = NativeModules
-  const [barHeight, setBarHeight] = useState(0)
-
-  useEffect(() => {
-    if (Platform.OS !== 'ios') return setBarHeight(StatusBar.currentHeight ?? 0)
-    // handling edge case when app is opened in landscape mode and barHeight = 0
-    const StatusBarManagerModule = NativeStatusBarManager?.default || StatusBarManager
-
-    StatusBarManagerModule?.getHeight(({ height }: { height: number }) =>
-      setBarHeight(isPortraitMode && height !== 0 ? height : 50)
-    )
-  }, [StatusBarManager, isPortraitMode])
-
+export const useStatusBarHeightDetector = ({ isPortraitMode: _ }: Props) => {
   return {
-    statusBarHeight: barHeight,
+    statusBarHeight: 0,
   }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/TheWidlarzGroup/react-native-notificated/issues/249

- split the status bar hook into non-native and native flavors to make the expo web app not crash