### PR TITLE
docs: update useNotificationsController hook example

### DIFF
--- a/docs/docs/api/apiReference.md
+++ b/docs/docs/api/apiReference.md
@@ -314,7 +314,7 @@ The hook is imported from 'react-native-notificated' and can be used only inside
 import { useNotificationsController } from 'react-native-notificated'
 
 const SomeFunctionComponent = () => {
-    const { modify, remove } = useNotifications()
+    const { modify, remove } = useNotificationsController()
 
     [...]
 }


### PR DESCRIPTION
Hello :wave:
While reviewing the documentation for the react-native-notificated library, which we're currently using in our project, I noticed a small inconsistency in the section describing the `useNotificationsController()` hook.

cc. @mateki0 
